### PR TITLE
build: remove boost dependency from test.cc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8.11)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")  
-find_package(Boost COMPONENTS thread system REQUIRED)
 find_package(LTTng REQUIRED)
 
 # make && make test

--- a/blkin-lib/tests/CMakeLists.txt
+++ b/blkin-lib/tests/CMakeLists.txt
@@ -1,14 +1,15 @@
 #test
 add_executable(testc test.c)
-target_link_libraries(testc blkin lttng-ust boost_system boost_thread)
+target_link_libraries(testc blkin lttng-ust)
 add_test(testc testc)
 
 #testpp
 add_executable(testpp test.cc)
-target_link_libraries(testpp blkin lttng-ust boost_system boost_thread)
+target_compile_options(testpp PRIVATE -std=c++11)
+target_link_libraries(testpp blkin lttng-ust pthread)
 add_test(testpp testpp)
 
 #testppp
 add_executable(testppp test_p.cc)
-target_link_libraries(testppp blkin lttng-ust boost_system boost_thread)
+target_link_libraries(testppp blkin lttng-ust)
 add_test(testppp testppp)

--- a/blkin-lib/tests/Makefile
+++ b/blkin-lib/tests/Makefile
@@ -35,10 +35,10 @@ test: test.c $(DLIB).so
 	gcc test.c -o test -g -I$(LIB_DIR) -L$(LIB_DIR) -lblkin
 
 testpp: test.cc $(DLIB).so
-	LD_LIBRARY_PATH=$(LIB_DIR) g++ $< -o testpp -g -I$(LIB_DIR) -L$(LIB_DIR) -lboost_thread -lboost_system -lblkin
+	LD_LIBRARY_PATH=$(LIB_DIR) g++ $< -o testpp -std=c++11 -g -I$(LIB_DIR) -L$(LIB_DIR) -lblkin -lpthread
 
 testppp: test_p.cc $(DLIB).so
-	LD_LIBRARY_PATH=$(LIB_DIR) g++ $< -o testppp -g -I$(LIB_DIR) -L$(LIB_DIR) -lboost_thread -lboost_system -lblkin
+	LD_LIBRARY_PATH=$(LIB_DIR) g++ $< -o testppp -g -I$(LIB_DIR) -L$(LIB_DIR) -lblkin
 
 run_c:
 	LD_LIBRARY_PATH=$(LIB_DIR) ./test

--- a/blkin-lib/tests/test.cc
+++ b/blkin-lib/tests/test.cc
@@ -27,7 +27,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <boost/thread.hpp>
+#include <thread>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -195,8 +195,8 @@ int main(int argc, const char *argv[])
 	}
 	Parent p;
 	Child c;
-	boost::thread workerThread1(p);
-	boost::thread workerThread2(c);
+	std::thread workerThread1(p);
+	std::thread workerThread2(c);
 	workerThread1.join();
 	workerThread2.join();
 

--- a/blkin-lib/tests/test_p.cc
+++ b/blkin-lib/tests/test_p.cc
@@ -27,13 +27,13 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <boost/thread.hpp>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <ztracer.hpp>
 #include <iostream>
+#include <cstdlib>
 
 #define SOCK_PATH "socket"
 

--- a/blkin-lib/ztracer.hpp
+++ b/blkin-lib/ztracer.hpp
@@ -31,6 +31,7 @@
 
 #define ZTRACER_H
 
+#include <string>
 extern "C" {
 #include <zipkin_c.h>
 }


### PR DESCRIPTION
avoid boost library conflicts when building inside of ceph