### PR TITLE
cmake: remove installed files

### DIFF
--- a/blkin-lib/CMakeLists.txt
+++ b/blkin-lib/CMakeLists.txt
@@ -9,13 +9,10 @@ add_library(blkin ${blkin_srcs})
 set_target_properties(blkin PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(blkin dl ${LTTNG_LIBRARIES})
 
-install(TARGETS blkin DESTINATION lib)
-
 set(blkin_headers
   zipkin_c.h
   zipkin_trace.h
   ztracer.hpp
 )
-install(FILES ${blkin_headers} DESTINATION include/blkin)
 
 add_subdirectory(tests)


### PR DESCRIPTION
installed files break ceph builds since they are
not packaged. This commit removes them.

Signed-off-by: Ali Maredia <amaredia@redhat.com>