### PR TITLE
cmake: set_target_properites() for additional compile flags

### DIFF
--- a/blkin-lib/tests/CMakeLists.txt
+++ b/blkin-lib/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ add_test(testc testc)
 
 #testpp
 add_executable(testpp test.cc)
-target_compile_options(testpp PRIVATE -std=c++11)
+set_target_properties(testpp PROPERTIES COMPILE_FLAGS "-std=c++11")
 target_link_libraries(testpp blkin lttng-ust pthread)
 add_test(testpp testpp)
 


### PR DESCRIPTION
target_compile_options() isn't available on older
cmake versions running on some systems

Signed-off-by: Ali Maredia <amaredia@redhat.com>