### PR TITLE
cmake: specify command for add_test as full path of binary

### DIFF
--- a/blkin-lib/tests/CMakeLists.txt
+++ b/blkin-lib/tests/CMakeLists.txt
@@ -1,15 +1,15 @@
 #test
 add_executable(testc test.c)
 target_link_libraries(testc blkin lttng-ust)
-add_test(testc testc)
+add_test(NAME testc COMMAND $<TARGET_FILE:testc>)
 
 #testpp
 add_executable(testpp test.cc)
 set_target_properties(testpp PROPERTIES COMPILE_FLAGS "-std=c++11")
 target_link_libraries(testpp blkin lttng-ust pthread)
-add_test(testpp testpp)
+add_test(NAME testpp COMMAND $<TARGET_FILE:testpp>)
 
 #testppp
 add_executable(testppp test_p.cc)
 target_link_libraries(testppp blkin lttng-ust)
-add_test(testppp testppp)
+add_test(NAME testppp COMMAND $<TARGET_FILE:testppp>)


### PR DESCRIPTION
Signed-off-by: Ali Maredia <amaredia@redhat.com>